### PR TITLE
Add automatic calculation of electron number from charge and atoms

### DIFF
--- a/Hartree_Fock_notebook.ipynb
+++ b/Hartree_Fock_notebook.ipynb
@@ -143,11 +143,12 @@
    "source": [
     "# Other book-keeping\n",
     "\n",
-    "# Number of electrons (Important!!)\n",
-    "N = 2\n",
-    "\n",
     "# Keep a dictionary of charges\n",
-    "charge_dict = {'H': 1, 'He': 2, 'Li':3, 'Be':4,'B':5,'C':6,'N':7,'O':8,'F':9,'Ne':10}"
+    "charge_dict = {'H': 1, 'He': 2, 'Li':3, 'Be':4,'B':5,'C':6,'N':7,'O':8,'F':9,'Ne':10}\n",
+    "\n",
+    "# Charge and number of electrons (Important!!)\n",
+    "Charge = 0\n",
+    "N = [charge_dict[atom] for atom in atoms]"
    ]
   },
   {
@@ -503,7 +504,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think there is no reason to make user calculating number of electrones in molecule by hand, so I added electron number calculation from charge and atoms list.